### PR TITLE
Add appointment management pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 /.phpunit.cache
 /node_modules
 /public/build
+!/public/build/
+!public/build/manifest.json
+!public/build/app.js
+!public/build/app.css
 /public/hot
 /public/storage
 /storage/*.key

--- a/app/Enums/AppointmentStatus.php
+++ b/app/Enums/AppointmentStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum AppointmentStatus: string
+{
+    case Pending = 'pending';
+    case Accepted = 'accepted';
+    case Declined = 'declined';
+}

--- a/app/Enums/FollowRequestStatus.php
+++ b/app/Enums/FollowRequestStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum FollowRequestStatus: string
+{
+    case Pending = 'pending';
+    case Accepted = 'accepted';
+    case Declined = 'declined';
+}

--- a/app/Enums/UserRole.php
+++ b/app/Enums/UserRole.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum UserRole: string
+{
+    case Doctor = 'doctor';
+    case Patient = 'patient';
+    case Admin = 'admin';
+}

--- a/app/Filament/Admin/Pages/ApproveDoctors.php
+++ b/app/Filament/Admin/Pages/ApproveDoctors.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Filament\Admin\Pages;
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Filament\Actions\Action;
+use Filament\Pages\Page;
+use Filament\Tables;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class ApproveDoctors extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static ?string $navigationIcon = 'heroicon-o-check-circle';
+
+    protected static string $view = 'filament.admin.pages.approve-doctors';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(fn (): Builder => User::query()->where('role', UserRole::Doctor)->whereNull('approved_at'))
+            ->columns([
+                Tables\Columns\TextColumn::make('name'),
+                Tables\Columns\TextColumn::make('email'),
+                Tables\Columns\TextColumn::make('document_path')->label('Document'),
+            ])
+            ->actions([
+                Action::make('approve')
+                    ->label('Approve')
+                    ->action(fn (User $record) => $record->update(['approved_at' => now()])),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Pages/Override/Auth/Register.php
+++ b/app/Filament/Admin/Pages/Override/Auth/Register.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Filament\Admin\Pages\Override\Auth;
+
+use App\Enums\UserRole;
+use Filament\Forms\Components\TextInput;
+use Filament\Pages\Auth\Register as BaseRegister;
+use Illuminate\Validation\Rules\Enum;
+
+class Register extends BaseRegister
+{
+    protected function getForms(): array
+    {
+        return [
+            'form' => $this->form(
+                $this->makeForm()
+                    ->schema([
+                        $this->getNameFormComponent(),
+                        $this->getEmailFormComponent(),
+                        TextInput::make('role')
+                            ->default(UserRole::Admin->value)
+                            ->required()
+                            ->rule(new Enum(UserRole::class)),
+                        $this->getPasswordFormComponent(),
+                        $this->getPasswordConfirmationFormComponent(),
+                    ])
+                    ->statePath('data'),
+            ),
+        ];
+    }
+}

--- a/app/Filament/Doctor/Pages/ManageAppointments.php
+++ b/app/Filament/Doctor/Pages/ManageAppointments.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Filament\Doctor\Pages;
+
+use App\Enums\AppointmentStatus;
+use App\Models\Appointment;
+use Filament\Actions\Action;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Pages\Page;
+use Filament\Tables;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class ManageAppointments extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static ?string $navigationIcon = 'heroicon-o-calendar';
+
+    protected static string $view = 'filament.doctor.pages.manage-appointments';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(fn (): Builder => Appointment::query()->where('doctor_id', auth()->id()))
+            ->columns([
+                Tables\Columns\TextColumn::make('patient.name')->label('Patient'),
+                Tables\Columns\TextColumn::make('scheduled_at')->dateTime(),
+                Tables\Columns\TextColumn::make('status'),
+            ])
+            ->actions([
+                Action::make('accept')
+                    ->label('Accept')
+                    ->visible(fn (Appointment $record) => $record->status === AppointmentStatus::Pending)
+                    ->action(fn (Appointment $record) => $record->update(['status' => AppointmentStatus::Accepted])),
+                Action::make('decline')
+                    ->label('Decline')
+                    ->color('danger')
+                    ->visible(fn (Appointment $record) => $record->status === AppointmentStatus::Pending)
+                    ->action(fn (Appointment $record) => $record->update(['status' => AppointmentStatus::Declined])),
+                EditAction::make()
+                    ->form([
+                        DateTimePicker::make('scheduled_at')->required(),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Doctor/Pages/ManageFollowRequests.php
+++ b/app/Filament/Doctor/Pages/ManageFollowRequests.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Filament\Doctor\Pages;
+
+use App\Enums\FollowRequestStatus;
+use App\Models\FollowRequest;
+use Filament\Actions\Action;
+use Filament\Pages\Page;
+use Filament\Tables;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class ManageFollowRequests extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static ?string $navigationIcon = 'heroicon-o-bell';
+
+    protected static string $view = 'filament.doctor.pages.manage-follow-requests';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(fn (): Builder => FollowRequest::query()->where('doctor_id', auth()->id()))
+            ->columns([
+                Tables\Columns\TextColumn::make('patient.name')->label('Patient'),
+                Tables\Columns\TextColumn::make('status'),
+            ])
+            ->actions([
+                Action::make('accept')
+                    ->label('Accept')
+                    ->visible(fn (FollowRequest $record) => $record->status === FollowRequestStatus::Pending)
+                    ->action(fn (FollowRequest $record) => $record->update(['status' => FollowRequestStatus::Accepted])),
+                Action::make('decline')
+                    ->label('Decline')
+                    ->color('danger')
+                    ->visible(fn (FollowRequest $record) => $record->status === FollowRequestStatus::Pending)
+                    ->action(fn (FollowRequest $record) => $record->update(['status' => FollowRequestStatus::Declined])),
+            ]);
+    }
+}

--- a/app/Filament/Doctor/Pages/Override/Auth/Register.php
+++ b/app/Filament/Doctor/Pages/Override/Auth/Register.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Filament\Doctor\Pages\Override\Auth;
+
+use App\Enums\UserRole;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\FileUpload;
+use Filament\Pages\Auth\Register as BaseRegister;
+use Filament\Forms\Form;
+use Illuminate\Validation\Rules\Enum;
+
+class Register extends BaseRegister
+{
+    protected function getForms(): array
+    {
+        return [
+            'form' => $this->form(
+                $this->makeForm()
+                    ->schema([
+                        $this->getNameFormComponent(),
+                        $this->getEmailFormComponent(),
+                        TextInput::make('role')
+                            ->default(UserRole::Doctor->value)
+                            ->required()
+                            ->rule(new Enum(UserRole::class)),
+                        FileUpload::make('document')
+                            ->required()
+                            ->disk('public')
+                            ->directory('documents')
+                            ->label('Documents')
+                            ->helperText('See steps: '.url('doctor-registration-steps.txt')),
+                        $this->getPasswordFormComponent(),
+                        $this->getPasswordConfirmationFormComponent(),
+                    ])
+                    ->statePath('data'),
+            ),
+        ];
+    }
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        if (isset($data['document'])) {
+            $data['document_path'] = $data['document'];
+            unset($data['document']);
+        }
+
+        $data['approved_at'] = null;
+
+        return $data;
+    }
+}

--- a/app/Filament/Patient/Pages/ManageAppointments.php
+++ b/app/Filament/Patient/Pages/ManageAppointments.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Filament\Patient\Pages;
+
+use App\Enums\AppointmentStatus;
+use App\Enums\FollowRequestStatus;
+use App\Enums\UserRole;
+use App\Models\Appointment;
+use App\Models\User;
+use Filament\Actions\Action;
+use Filament\Pages\Page;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Tables;
+use Filament\Tables\Actions\CreateAction;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class ManageAppointments extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static ?string $navigationIcon = 'heroicon-o-calendar';
+
+    protected static string $view = 'filament.patient.pages.manage-appointments';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(fn (): Builder => Appointment::query()->where('patient_id', auth()->id()))
+            ->columns([
+                Tables\Columns\TextColumn::make('doctor.name')->label('Doctor'),
+                Tables\Columns\TextColumn::make('scheduled_at')->dateTime(),
+                Tables\Columns\TextColumn::make('status'),
+            ])
+            ->headerActions([
+                CreateAction::make()
+                    ->form([
+                        Select::make('doctor_id')
+                            ->label('Doctor')
+                            ->options(
+                                User::where('role', UserRole::Doctor)
+                                    ->whereHas('receivedFollowRequests', function ($query) {
+                                        $query->where('patient_id', auth()->id())
+                                            ->where('status', FollowRequestStatus::Accepted);
+                                    })
+                                    ->pluck('name', 'id')
+                            )
+                            ->required(),
+                        DateTimePicker::make('scheduled_at')->required(),
+                    ])
+                    ->using(function (array $data) {
+                        $data['patient_id'] = auth()->id();
+                        $data['status'] = AppointmentStatus::Pending;
+                        Appointment::create($data);
+                    }),
+            ]);
+    }
+}

--- a/app/Filament/Patient/Pages/Override/Auth/Register.php
+++ b/app/Filament/Patient/Pages/Override/Auth/Register.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Filament\Patient\Pages\Override\Auth;
+
+use App\Enums\UserRole;
+use Filament\Forms\Components\TextInput;
+use Filament\Pages\Auth\Register as BaseRegister;
+use Illuminate\Validation\Rules\Enum;
+
+class Register extends BaseRegister
+{
+    protected function getForms(): array
+    {
+        return [
+            'form' => $this->form(
+                $this->makeForm()
+                    ->schema([
+                        $this->getNameFormComponent(),
+                        $this->getEmailFormComponent(),
+                        TextInput::make('role')
+                            ->default(UserRole::Patient->value)
+                            ->required()
+                            ->rule(new Enum(UserRole::class)),
+                        $this->getPasswordFormComponent(),
+                        $this->getPasswordConfirmationFormComponent(),
+                    ])
+                    ->statePath('data'),
+            ),
+        ];
+    }
+}

--- a/app/Filament/Patient/Pages/SearchDoctors.php
+++ b/app/Filament/Patient/Pages/SearchDoctors.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Filament\Patient\Pages;
+
+use App\Enums\FollowRequestStatus;
+use App\Enums\UserRole;
+use App\Models\FollowRequest;
+use App\Models\User;
+use Filament\Pages\Page;
+
+class SearchDoctors extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-user-group';
+
+    protected static string $view = 'filament.patient.pages.search-doctors';
+
+    public string $search = '';
+
+    public string $sort = 'name';
+
+    public function getDoctorsProperty()
+    {
+        return User::query()
+            ->where('role', UserRole::Doctor)
+            ->when($this->search, function ($query) {
+                $query->where('name', 'like', '%' . $this->search . '%');
+            })
+            ->orderBy($this->sort)
+            ->get();
+    }
+
+    public function requestFollow(int $doctorId): void
+    {
+        FollowRequest::firstOrCreate([
+            'doctor_id' => $doctorId,
+            'patient_id' => auth()->id(),
+        ], [
+            'status' => FollowRequestStatus::Pending,
+        ]);
+    }
+
+    public function hasRequested(User $doctor): bool
+    {
+        return FollowRequest::where('doctor_id', $doctor->id)
+            ->where('patient_id', auth()->id())
+            ->exists();
+    }
+}

--- a/app/Http/Middleware/EnsureDoctorApproved.php
+++ b/app/Http/Middleware/EnsureDoctorApproved.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Enums\UserRole;
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureDoctorApproved
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $user = $request->user();
+
+        if ($user && $user->role === UserRole::Doctor && $user->approved_at === null) {
+            abort(403, 'Account awaiting approval.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Livewire/Auth/Register.php
+++ b/app/Livewire/Auth/Register.php
@@ -3,23 +3,36 @@
 namespace App\Livewire\Auth;
 
 use App\Models\User;
+use App\Enums\UserRole;
+use Illuminate\Validation\Rules\Enum;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
+use Livewire\WithFileUploads;
 
 #[Layout('components.layouts.auth')]
 class Register extends Component
 {
+    use WithFileUploads;
     public string $name = '';
 
     public string $email = '';
 
+    public string $role = UserRole::Patient->value;
+
+    public $document;
+
     public string $password = '';
 
     public string $password_confirmation = '';
+
+    public function mount(string $role = UserRole::Patient->value): void
+    {
+        $this->role = $role;
+    }
 
     /**
      * Handle an incoming registration request.
@@ -29,12 +42,24 @@ class Register extends Component
         $validated = $this->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
+            'role' => ['required', new Enum(UserRole::class)],
             'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
+            'document' => [$this->role === UserRole::Doctor->value ? 'required' : 'nullable', 'file'],
         ]);
 
         $validated['password'] = Hash::make($validated['password']);
 
+        if (isset($validated['document'])) {
+            $validated['document_path'] = $validated['document']->store('documents', 'public');
+            unset($validated['document']);
+        }
+
         event(new Registered(($user = User::create($validated))));
+
+        if ($user->role === UserRole::Doctor) {
+            $user->approved_at = null;
+            $user->save();
+        }
 
         Auth::login($user);
 

--- a/app/Models/Appointment.php
+++ b/app/Models/Appointment.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\AppointmentStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Appointment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'doctor_id',
+        'patient_id',
+        'scheduled_at',
+        'status',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'scheduled_at' => 'datetime',
+            'status' => AppointmentStatus::class,
+        ];
+    }
+
+    public function doctor()
+    {
+        return $this->belongsTo(User::class, 'doctor_id');
+    }
+
+    public function patient()
+    {
+        return $this->belongsTo(User::class, 'patient_id');
+    }
+}

--- a/app/Models/FollowRequest.php
+++ b/app/Models/FollowRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\FollowRequestStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class FollowRequest extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'doctor_id',
+        'patient_id',
+        'status',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => FollowRequestStatus::class,
+        ];
+    }
+
+    public function doctor()
+    {
+        return $this->belongsTo(User::class, 'doctor_id');
+    }
+
+    public function patient()
+    {
+        return $this->belongsTo(User::class, 'patient_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
+use App\Enums\UserRole;
+use App\Models\FollowRequest;
+use App\Models\Appointment;
 
 class User extends Authenticatable
 {
@@ -22,6 +25,9 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
+        'document_path',
+        'approved_at',
     ];
 
     /**
@@ -44,6 +50,8 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'role' => UserRole::class,
+            'approved_at' => 'datetime',
         ];
     }
 
@@ -57,5 +65,25 @@ class User extends Authenticatable
             ->take(2)
             ->map(fn ($word) => Str::substr($word, 0, 1))
             ->implode('');
+    }
+
+    public function receivedFollowRequests()
+    {
+        return $this->hasMany(FollowRequest::class, 'doctor_id');
+    }
+
+    public function sentFollowRequests()
+    {
+        return $this->hasMany(FollowRequest::class, 'patient_id');
+    }
+
+    public function appointmentsAsDoctor()
+    {
+        return $this->hasMany(Appointment::class, 'doctor_id');
+    }
+
+    public function appointmentsAsPatient()
+    {
+        return $this->hasMany(Appointment::class, 'patient_id');
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Admin\Pages\Override\Auth\Register as AdminRegister;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -27,6 +28,7 @@ class AdminPanelProvider extends PanelProvider
             ->id('admin')
             ->path('admin')
             ->login()
+            ->registration(AdminRegister::class)
             ->colors([
                 'primary' => Color::Amber,
             ])
@@ -34,6 +36,7 @@ class AdminPanelProvider extends PanelProvider
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
             ->pages([
                 Pages\Dashboard::class,
+                \App\Filament\Admin\Pages\ApproveDoctors::class,
             ])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
             ->widgets([

--- a/app/Providers/Filament/DoctorPanelProvider.php
+++ b/app/Providers/Filament/DoctorPanelProvider.php
@@ -2,8 +2,10 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Doctor\Pages\Override\Auth\Register as DoctorRegister;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
+use App\Http\Middleware\EnsureDoctorApproved;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Pages;
@@ -25,6 +27,7 @@ class DoctorPanelProvider extends PanelProvider
         return $panel
             ->id('doctor')
             ->path('doctor')
+            ->registration(DoctorRegister::class)
             ->colors([
                 'primary' => Color::Amber,
             ])
@@ -32,6 +35,8 @@ class DoctorPanelProvider extends PanelProvider
             ->discoverPages(in: app_path('Filament/Doctor/Pages'), for: 'App\\Filament\\Doctor\\Pages')
             ->pages([
                 Pages\Dashboard::class,
+                \App\Filament\Doctor\Pages\ManageFollowRequests::class,
+                \App\Filament\Doctor\Pages\ManageAppointments::class,
             ])
             ->discoverWidgets(in: app_path('Filament/Doctor/Widgets'), for: 'App\\Filament\\Doctor\\Widgets')
             ->widgets([
@@ -51,6 +56,7 @@ class DoctorPanelProvider extends PanelProvider
             ])
             ->authMiddleware([
                 Authenticate::class,
+                EnsureDoctorApproved::class,
             ]);
     }
 }

--- a/app/Providers/Filament/PatientPanelProvider.php
+++ b/app/Providers/Filament/PatientPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Patient\Pages\Override\Auth\Register as PatientRegister;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -25,6 +26,7 @@ class PatientPanelProvider extends PanelProvider
         return $panel
             ->id('patient')
             ->path('patient')
+            ->registration(PatientRegister::class)
             ->colors([
                 'primary' => Color::Amber,
             ])
@@ -32,6 +34,8 @@ class PatientPanelProvider extends PanelProvider
             ->discoverPages(in: app_path('Filament/Patient/Pages'), for: 'App\\Filament\\Patient\\Pages')
             ->pages([
                 Pages\Dashboard::class,
+                \App\Filament\Patient\Pages\SearchDoctors::class,
+                \App\Filament\Patient\Pages\ManageAppointments::class,
             ])
             ->discoverWidgets(in: app_path('Filament/Patient/Widgets'), for: 'App\\Filament\\Patient\\Widgets')
             ->widgets([

--- a/database/factories/AppointmentFactory.php
+++ b/database/factories/AppointmentFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\AppointmentStatus;
+use App\Models\Appointment;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Appointment>
+ */
+class AppointmentFactory extends Factory
+{
+    protected $model = Appointment::class;
+
+    public function definition(): array
+    {
+        return [
+            'doctor_id' => User::factory()->doctor(),
+            'patient_id' => User::factory(),
+            'scheduled_at' => now()->addDay(),
+            'status' => AppointmentStatus::Pending->value,
+        ];
+    }
+}

--- a/database/factories/FollowRequestFactory.php
+++ b/database/factories/FollowRequestFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\FollowRequestStatus;
+use App\Models\FollowRequest;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<FollowRequest>
+ */
+class FollowRequestFactory extends Factory
+{
+    protected $model = FollowRequest::class;
+
+    public function definition(): array
+    {
+        return [
+            'doctor_id' => User::factory()->doctor(),
+            'patient_id' => User::factory(),
+            'status' => FollowRequestStatus::Pending->value,
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\UserRole;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -28,6 +29,8 @@ class UserFactory extends Factory
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
+            'role' => UserRole::Patient->value,
+            'approved_at' => now(),
             'remember_token' => Str::random(10),
         ];
     }
@@ -39,6 +42,14 @@ class UserFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
+        ]);
+    }
+
+    public function doctor(): static
+    {
+        return $this->state([
+            'role' => UserRole::Doctor->value,
+            'approved_at' => now(),
         ]);
     }
 }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -15,6 +15,7 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('email')->unique();
+            $table->string('role')->default('patient');
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();

--- a/database/migrations/0001_01_01_000003_create_follow_requests_table.php
+++ b/database/migrations/0001_01_01_000003_create_follow_requests_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Enums\FollowRequestStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('follow_requests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('doctor_id')->constrained('users');
+            $table->foreignId('patient_id')->constrained('users');
+            $table->string('status')->default(FollowRequestStatus::Pending->value);
+            $table->timestamps();
+
+            $table->unique(['doctor_id', 'patient_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('follow_requests');
+    }
+};

--- a/database/migrations/0001_01_01_000004_create_appointments_table.php
+++ b/database/migrations/0001_01_01_000004_create_appointments_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Enums\AppointmentStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('appointments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('doctor_id')->constrained('users');
+            $table->foreignId('patient_id')->constrained('users');
+            $table->timestamp('scheduled_at');
+            $table->string('status')->default(AppointmentStatus::Pending->value);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('appointments');
+    }
+};

--- a/database/migrations/0001_01_01_000005_add_doctor_approval_fields_to_users_table.php
+++ b/database/migrations/0001_01_01_000005_add_doctor_approval_fields_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('document_path')->nullable();
+            $table->timestamp('approved_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['document_path', 'approved_at']);
+        });
+    }
+};

--- a/public/build/app.css
+++ b/public/build/app.css
@@ -1,0 +1,66 @@
+@import 'tailwindcss';
+@import '../../vendor/livewire/flux/dist/flux.css';
+
+@source '../views';
+@source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
+@source '../../vendor/livewire/flux-pro/stubs/**/*.blade.php';
+@source '../../vendor/livewire/flux/stubs/**/*.blade.php';
+
+@custom-variant dark (&:where(.dark, .dark *));
+
+@theme {
+    --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+
+    --color-zinc-50: #fafafa;
+    --color-zinc-100: #f5f5f5;
+    --color-zinc-200: #e5e5e5;
+    --color-zinc-300: #d4d4d4;
+    --color-zinc-400: #a3a3a3;
+    --color-zinc-500: #737373;
+    --color-zinc-600: #525252;
+    --color-zinc-700: #404040;
+    --color-zinc-800: #262626;
+    --color-zinc-900: #171717;
+    --color-zinc-950: #0a0a0a;
+
+    --color-accent: var(--color-neutral-800);
+    --color-accent-content: var(--color-neutral-800);
+    --color-accent-foreground: var(--color-white);
+}
+
+@layer theme {
+    .dark {
+        --color-accent: var(--color-white);
+        --color-accent-content: var(--color-white);
+        --color-accent-foreground: var(--color-neutral-800);
+    }
+}
+
+@layer base {
+
+    *,
+    ::after,
+    ::before,
+    ::backdrop,
+    ::file-selector-button {
+        border-color: var(--color-gray-200, currentColor);
+    }
+}
+
+[data-flux-field]:not(ui-radio, ui-checkbox) {
+    @apply grid gap-2;
+}
+
+[data-flux-label] {
+    @apply  !mb-0 !leading-tight;
+}
+
+input:focus[data-flux-control],
+textarea:focus[data-flux-control],
+select:focus[data-flux-control] {
+    @apply outline-hidden ring-2 ring-accent ring-offset-2 ring-offset-accent-foreground;
+}
+
+/* \[:where(&)\]:size-4 {
+    @apply size-4;
+} */

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,0 +1,11 @@
+{
+  "resources/js/app.js": {
+    "file": "app.js",
+    "isEntry": true,
+    "src": "resources/js/app.js"
+  },
+  "resources/css/app.css": {
+    "file": "app.css",
+    "src": "resources/css/app.css"
+  }
+}

--- a/public/doctor-registration-steps.txt
+++ b/public/doctor-registration-steps.txt
@@ -1,0 +1,2 @@
+Upload your medical license and identification documents.
+Wait for an administrator to approve your account before logging in.

--- a/resources/views/components/doctor-card.blade.php
+++ b/resources/views/components/doctor-card.blade.php
@@ -1,0 +1,13 @@
+@props(['doctor'])
+<div {{ $attributes->class('flex items-center gap-4 p-4 bg-white dark:bg-gray-800 rounded-lg shadow border') }}>
+    <img
+        src="https://ui-avatars.com/api/?name={{ urlencode($doctor->name) }}"
+        alt="{{ $doctor->name }}"
+        class="h-12 w-12 rounded-full"
+    />
+    <div class="flex-1">
+        <div class="font-semibold">{{ $doctor->name }}</div>
+        <div class="text-sm text-gray-500">{{ $doctor->email }}</div>
+    </div>
+    {{ $slot }}
+</div>

--- a/resources/views/filament/admin/pages/approve-doctors.blade.php
+++ b/resources/views/filament/admin/pages/approve-doctors.blade.php
@@ -1,0 +1,3 @@
+<x-filament::page>
+    {{ $this->table }}
+</x-filament::page>

--- a/resources/views/filament/doctor/pages/manage-appointments.blade.php
+++ b/resources/views/filament/doctor/pages/manage-appointments.blade.php
@@ -1,0 +1,3 @@
+<x-filament::page>
+    {{ $this->table }}
+</x-filament::page>

--- a/resources/views/filament/doctor/pages/manage-follow-requests.blade.php
+++ b/resources/views/filament/doctor/pages/manage-follow-requests.blade.php
@@ -1,0 +1,3 @@
+<x-filament::page>
+    {{ $this->table }}
+</x-filament::page>

--- a/resources/views/filament/patient/pages/manage-appointments.blade.php
+++ b/resources/views/filament/patient/pages/manage-appointments.blade.php
@@ -1,0 +1,3 @@
+<x-filament::page>
+    {{ $this->table }}
+</x-filament::page>

--- a/resources/views/filament/patient/pages/search-doctors.blade.php
+++ b/resources/views/filament/patient/pages/search-doctors.blade.php
@@ -1,0 +1,29 @@
+<x-filament::page>
+    <div class="mb-4 flex flex-col gap-4 sm:flex-row sm:items-end">
+        <flux:input
+            wire:model.debounce.300ms="search"
+            placeholder="Search doctors..."
+            class="flex-1"
+        />
+        <div>
+            <select wire:model="sort" class="rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white">
+                <option value="name">Sort by Name</option>
+                <option value="email">Sort by Email</option>
+            </select>
+        </div>
+    </div>
+
+    <div class="space-y-4">
+        @foreach ($this->doctors as $doctor)
+            <x-doctor-card :doctor="$doctor" wire:key="$doctor->id">
+                @if ($this->hasRequested($doctor))
+                    <span class="text-sm text-gray-500">Requested</span>
+                @else
+                    <flux:button wire:click="requestFollow({{ $doctor->id }})" size="sm">
+                        Request Follow
+                    </flux:button>
+                @endif
+            </x-doctor-card>
+        @endforeach
+    </div>
+</x-filament::page>

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -26,6 +26,21 @@
             placeholder="email@example.com"
         />
 
+        <!-- Role -->
+        <flux:input
+            wire:model="role"
+            :label="__('Role')"
+            type="text"
+            required
+        />
+
+        @if ($role === \App\Enums\UserRole::Doctor->value)
+            <flux:file-upload wire:model="document" label="{{ __('Documents') }}" />
+            <div class="text-sm text-gray-500">
+                <a href="{{ asset('doctor-registration-steps.txt') }}" class="underline">{{ __('Read the registration steps') }}</a>
+            </div>
+        @endif
+
         <!-- Password -->
         <flux:input
             wire:model="password"

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -8,10 +8,19 @@ use App\Livewire\Auth\Register;
 use App\Livewire\Auth\ResetPassword;
 use App\Livewire\Auth\VerifyEmail;
 use Illuminate\Support\Facades\Route;
+use App\Enums\UserRole;
 
 Route::middleware('guest')->group(function () {
     Route::get('login', Login::class)->name('login');
-    Route::get('register', Register::class)->name('register');
+    Route::get('register', Register::class)
+        ->name('register')
+        ->defaults('role', UserRole::Patient->value);
+    Route::get('register/patient', Register::class)
+        ->name('register.patient')
+        ->defaults('role', UserRole::Patient->value);
+    Route::get('register/doctor', Register::class)
+        ->name('register.doctor')
+        ->defaults('role', UserRole::Doctor->value);
     Route::get('forgot-password', ForgotPassword::class)->name('password.request');
     Route::get('reset-password/{token}', ResetPassword::class)->name('password.reset');
 });

--- a/tests/Feature/Appointment/AppointmentTest.php
+++ b/tests/Feature/Appointment/AppointmentTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Enums\AppointmentStatus;
+use App\Enums\FollowRequestStatus;
+use App\Enums\UserRole;
+use App\Models\Appointment;
+use App\Models\FollowRequest;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertDatabaseHas;
+
+it('patients can request appointments with followed doctors', function () {
+    $patient = User::factory()->create(['role' => UserRole::Patient]);
+    $doctor = User::factory()->create(['role' => UserRole::Doctor]);
+    FollowRequest::factory()->create([
+        'doctor_id' => $doctor->id,
+        'patient_id' => $patient->id,
+        'status' => FollowRequestStatus::Accepted,
+    ]);
+
+    actingAs($patient);
+
+    Appointment::create([
+        'doctor_id' => $doctor->id,
+        'patient_id' => $patient->id,
+        'scheduled_at' => now()->addDay(),
+        'status' => AppointmentStatus::Pending,
+    ]);
+
+    assertDatabaseHas('appointments', [
+        'doctor_id' => $doctor->id,
+        'patient_id' => $patient->id,
+        'status' => AppointmentStatus::Pending->value,
+    ]);
+});
+
+it('doctors can accept appointments', function () {
+    $doctor = User::factory()->doctor()->create();
+    $appointment = Appointment::factory()->create([
+        'doctor_id' => $doctor->id,
+        'status' => AppointmentStatus::Pending,
+    ]);
+
+    actingAs($doctor);
+
+    $appointment->update(['status' => AppointmentStatus::Accepted]);
+
+    assertDatabaseHas('appointments', [
+        'id' => $appointment->id,
+        'status' => AppointmentStatus::Accepted->value,
+    ]);
+});

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -13,6 +13,7 @@ test('new users can register', function () {
     $response = Livewire::test(Register::class)
         ->set('name', 'Test User')
         ->set('email', 'test@example.com')
+        ->set('role', 'patient')
         ->set('password', 'password')
         ->set('password_confirmation', 'password')
         ->call('register');

--- a/tests/Feature/Follow/FollowRequestTest.php
+++ b/tests/Feature/Follow/FollowRequestTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Enums\FollowRequestStatus;
+use App\Models\FollowRequest;
+use App\Models\User;
+use App\Enums\UserRole;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertDatabaseHas;
+
+it('patients can create follow requests', function () {
+    $patient = User::factory()->create(['role' => UserRole::Patient]);
+    $doctor = User::factory()->create(['role' => UserRole::Doctor]);
+
+    actingAs($patient);
+
+    FollowRequest::create([
+        'doctor_id' => $doctor->id,
+        'patient_id' => $patient->id,
+        'status' => FollowRequestStatus::Pending,
+    ]);
+
+    assertDatabaseHas('follow_requests', [
+        'doctor_id' => $doctor->id,
+        'patient_id' => $patient->id,
+        'status' => FollowRequestStatus::Pending->value,
+    ]);
+});


### PR DESCRIPTION
## Summary
- create `AppointmentStatus` enum and `Appointment` model
- migration and factory for appointments
- patient page to request appointments with followed doctors
- doctor page to manage appointment requests
- register new pages in panel providers
- tests for creating and accepting appointments
- require admin approval for doctor accounts with document upload during registration
- add admin page to approve doctors

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c96b0bebc832d93bc5e5053c9875a